### PR TITLE
Add basic helm chart that works on k3s

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -46,7 +46,6 @@ jobs:
           type=sha
 
     - name: Login to Docker Hub
-      if: github.event_name != 'pull_request'
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -59,7 +58,7 @@ jobs:
       uses: docker/build-push-action@v6
       with:
         context: .
-        push: ${{ github.event_name != 'pull_request' }}
+        push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         platforms: linux/amd64,linux/arm64

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,0 +1,25 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/charts/kubelish/Chart.yaml
+++ b/charts/kubelish/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+name: kubelish
+description: mDNS service publisher for Kubernetes cluster nodes
+version: 0.0.1
+appVersion: 4.0.1

--- a/charts/kubelish/templates/daemonset.yaml
+++ b/charts/kubelish/templates/daemonset.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ .Release.Name }}
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      name: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        name: {{ .Release.Name }}
+    spec:
+      tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      terminationGracePeriodSeconds: 30
+      hostNetwork: true
+      containers:
+      - image: "{{ .Values.image.repository}}:{{ .Values.image.tag }}"
+        command: ["/kubelish"]
+        args: ["--namespace", "default", "watch"]
+        name: {{ .Release.Name }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "100m"
+          limits:
+            memory: "64Mi"
+            cpu: "200m"
+        volumeMounts:
+          - name: dbus
+            mountPath: /var/run/dbus
+          - name: kubeconfig
+            mountPath: /root/.kube/config
+      volumes:
+      - name: dbus
+        hostPath:
+          path: /var/run/dbus
+      - name: kubeconfig
+        hostPath:
+          path: /etc/rancher/k3s/k3s.yaml

--- a/charts/kubelish/templates/daemonset.yaml
+++ b/charts/kubelish/templates/daemonset.yaml
@@ -37,12 +37,7 @@ spec:
         volumeMounts:
           - name: dbus
             mountPath: /var/run/dbus
-          - name: kubeconfig
-            mountPath: /root/.kube/config
       volumes:
       - name: dbus
         hostPath:
           path: /var/run/dbus
-      - name: kubeconfig
-        hostPath:
-          path: /etc/rancher/k3s/k3s.yaml

--- a/charts/kubelish/templates/daemonset.yaml
+++ b/charts/kubelish/templates/daemonset.yaml
@@ -21,6 +21,7 @@ spec:
         effect: NoSchedule
       terminationGracePeriodSeconds: 30
       hostNetwork: true
+      serviceAccountName: {{ .Release.Name }}
       containers:
       - image: "{{ .Values.image.repository}}:{{ .Values.image.tag }}"
         command: ["/kubelish"]

--- a/charts/kubelish/templates/service-account.yaml
+++ b/charts/kubelish/templates/service-account.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}
+rules:
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: kubelish
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/kubelish/values.yaml
+++ b/charts/kubelish/values.yaml
@@ -3,6 +3,6 @@ image:
   # repository is the path to the repository from which the image should be pulled
   repository: holoplot/kubelish
   # tag is the version of the image that should be pulled from the repository
-  tag: 4.0.1
+  tag: pr-6
   # pullPolicy dictates when an image is pulled when a pod is created, it may be Always, Never, or IfNotPresent
   pullPolicy: IfNotPresent

--- a/charts/kubelish/values.yaml
+++ b/charts/kubelish/values.yaml
@@ -3,6 +3,6 @@ image:
   # repository is the path to the repository from which the image should be pulled
   repository: holoplot/kubelish
   # tag is the version of the image that should be pulled from the repository
-  tag: pr-6
+  tag: sha-26ea187
   # pullPolicy dictates when an image is pulled when a pod is created, it may be Always, Never, or IfNotPresent
   pullPolicy: IfNotPresent

--- a/charts/kubelish/values.yaml
+++ b/charts/kubelish/values.yaml
@@ -1,0 +1,8 @@
+# image is the image used to manage kubelish
+image:
+  # repository is the path to the repository from which the image should be pulled
+  repository: holoplot/kubelish
+  # tag is the version of the image that should be pulled from the repository
+  tag: 4.0.1
+  # pullPolicy dictates when an image is pulled when a pod is created, it may be Always, Never, or IfNotPresent
+  pullPolicy: IfNotPresent

--- a/pkg/k8s-watcher/watcher.go
+++ b/pkg/k8s-watcher/watcher.go
@@ -11,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -125,9 +126,19 @@ func (w *Watcher) Close() {
 }
 
 func New(kubeConfigPath, namespace string, serviceType corev1.ServiceType, onUpdate OnUpdateFunc, onDelete OnDeleteFunc) (*Watcher, error) {
-	config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
-	if err != nil {
-		panic(err)
+	var config *rest.Config
+	var err error
+
+	if kubeConfigPath == "" {
+		config, err = rest.InClusterConfig()
+		if err != nil {
+			panic(err)
+		}
+	} else {
+		config, err = clientcmd.BuildConfigFromFlags("", kubeConfigPath)
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	clientSet, err := kubernetes.NewForConfig(config)

--- a/pkg/k8s-watcher/watcher.go
+++ b/pkg/k8s-watcher/watcher.go
@@ -129,13 +129,9 @@ func New(kubeConfigPath, namespace string, serviceType corev1.ServiceType, onUpd
 	var config *rest.Config
 	var err error
 
-	if kubeConfigPath == "" {
+	config, err = clientcmd.BuildConfigFromFlags("", kubeConfigPath)
+	if err != nil {
 		config, err = rest.InClusterConfig()
-		if err != nil {
-			panic(err)
-		}
-	} else {
-		config, err = clientcmd.BuildConfigFromFlags("", kubeConfigPath)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
This is currently not production ready as the pods are over privileged in that they have the full fat admin kube config mounted in from the host. A patch set to make kubelish use a service account from the environment will follow shortly.